### PR TITLE
Use a blown-up, blurred & darkened photo for background

### DIFF
--- a/src/FK_TVbox.py
+++ b/src/FK_TVbox.py
@@ -42,7 +42,7 @@ else:
     import configparser
     ConfigParser = configparser
 
-from PIL import Image, ImageTk
+from PIL import Image, ImageTk, ImageEnhance, ImageFilter  
 import functools
 import time
 from datetime import datetime
@@ -401,11 +401,39 @@ class TVbox():
         imgWidth, imgHeight = pilImage.size
         print ('SHOWING', image_file, imgWidth, imgHeight, self.w, self.h-self.h_label)
         sys.stdout.flush()
+
+        # Generate the background
+        if imgWidth < self.w : # Our image is smaller then the screen
+           imgRatio = imgWidth / imgHeight # Keep the original image ratio
+           BackgroundImgWidth = int(self.w * 1.5) # Blow that photo up, nicer effect
+           BackgroundImgHeight = int((BackgroundImgWidth / imgRatio))
+           pilBackgroundImage = pilImage.resize((BackgroundImgWidth, BackgroundImgHeight), Image.ANTIALIAS)  
+
+        else: 
+           imgRatio = imgWidth / imgHeight 
+           BackgroundImgHeight = int(self.h * 1.5)
+           BackgroundImgWidth = int(imgRatio * BackgroundImgHeight)
+           pilBackgroundImage = pilImage.resize((BackgroundImgWidth, BackgroundImgHeight), Image.ANTIALIAS)
+
+        # Blur and darken the background photo
+        pilBackgroundImage = pilBackgroundImage.filter(ImageFilter.GaussianBlur(radius = 5))
+        enhancer = ImageEnhance.Brightness(pilBackgroundImage)
+        pilBackgroundImage = enhancer.enhance(0.25) # lower than 1 darkens the image
+
+        # Generate the true in-focus picture 
         # too large or too small, scale to fit the frame
         ratio = min(self.w/imgWidth, (self.h-self.h_label)/imgHeight)
         imgWidth = int(imgWidth*ratio)
         imgHeight = int(imgHeight*ratio)
-        pilImage = pilImage.resize((imgWidth, imgHeight), Image.ANTIALIAS)
+        pilForgroundImage = pilImage.resize((imgWidth, imgHeight), Image.ANTIALIAS)
+
+        # Paste the Forground on top of the background
+        # test:
+        # pilImage = pilBackgroundImage
+        offset = ((BackgroundImgWidth - imgWidth) // 2, (BackgroundImgHeight - imgHeight) // 2)
+        pilBackgroundImage.paste(pilForgroundImage, offset)
+        
+        pilImage = pilBackgroundImage
         self.image = ImageTk.PhotoImage(pilImage)
         imagesprite = self.canvas.create_image(self.w/2, 
                                                (self.h-self.h_label)/2, 

--- a/src/FK_TVbox.py
+++ b/src/FK_TVbox.py
@@ -409,11 +409,27 @@ class TVbox():
            BackgroundImgHeight = int((BackgroundImgWidth / imgRatio))
            pilBackgroundImage = pilImage.resize((BackgroundImgWidth, BackgroundImgHeight), Image.ANTIALIAS)  
 
-        else: 
+        elif imgHeight < self.h: 
            imgRatio = imgWidth / imgHeight 
            BackgroundImgHeight = int(self.h * 1.5)
            BackgroundImgWidth = int(imgRatio * BackgroundImgHeight)
            pilBackgroundImage = pilImage.resize((BackgroundImgWidth, BackgroundImgHeight), Image.ANTIALIAS)
+
+        else:
+           # The photo is equal or bigger than the screen, so scale it to that screen
+           
+           imgRatio = imgWidth / imgHeight
+           BackgroundImgWidth = int(self.w * 1.5) # Blow that photo up, nicer effect
+           BackgroundImgHeight = int((BackgroundImgWidth / imgRatio))
+
+           if BackgroundImgHeight < self.h: # We scaled using the wrong parameter
+              BackgroundImgHeight = int(self.h * 1.5)
+              BackgroundImgWidth = int(imgRatio * BackgroundImgHeight)
+
+           pilBackgroundImage = pilImage.resize((BackgroundImgWidth, BackgroundImgHeight), Image.ANTIALIAS)
+           
+        print("Backround_w, h:", BackgroundImgWidth, BackgroundImgHeight)
+        sys.stdout.flush()
 
         # Blur and darken the background photo
         pilBackgroundImage = pilBackgroundImage.filter(ImageFilter.GaussianBlur(radius = 5))

--- a/src/FK_TVbox.py
+++ b/src/FK_TVbox.py
@@ -434,7 +434,7 @@ class TVbox():
         # Blur and darken the background photo
         pilBackgroundImage = pilBackgroundImage.filter(ImageFilter.GaussianBlur(radius = 5))
         enhancer = ImageEnhance.Brightness(pilBackgroundImage)
-        pilBackgroundImage = enhancer.enhance(0.25) # lower than 1 darkens the image
+        pilBackgroundImage = enhancer.enhance(0.5) # lower than 1 darkens the image
 
         # Generate the true in-focus picture 
         # too large or too small, scale to fit the frame


### PR DESCRIPTION
When the photo does not fit the screen, it gets recaled. Unless the photo has the same imgRatio as the screen, this
results in black bars either at the left/right (when portrait) or above/below (landscape) of the photo. Although it
does the trick, it looks kind of ugly and and beginning 2000.

Here, the background is generated from the shown image. Subsequently, it gets blown up, blurred and darkened to remain an emphasis on the "true" picture, wich is the rescaled one in the center. The result is nothing else but slick, especially when the photo was made in portrait mode. 

This is what an example looks like in the current code:
![portrain_NoRescale](https://user-images.githubusercontent.com/1286494/97791144-69ac1e80-1bcf-11eb-8ce7-41178a3fbbb5.png)
Which will become:
![portrain_rescale](https://user-images.githubusercontent.com/1286494/97797916-78232600-1c21-11eb-8f14-34aa75046492.png)

Note that:
 - Specific values for the blow-up, blurring and darkening, might need some tweaking.
 - I have not tested this yet on a full-blown photo collection.


I value our opinion!
Erwin